### PR TITLE
Fixing typo in unregistering an event when disabling Show Closest Segment.

### DIFF
--- a/WMEPIE.js
+++ b/WMEPIE.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         WME Place Interface Enhancements
 // @namespace    https://greasyfork.org/users/30701-justins83-waze
-// @version      2019.05.31.01
+// @version      2019.06.10.01
 // @description  Enhancements to various Place interfaces
 // @include      https://www.waze.com/editor*
 // @include      https://www.waze.com/*/editor*
@@ -421,7 +421,7 @@ var UpdateObject, MultiAction;
                 W.model.venues.on('objectschanged', ObjectsChanged);
             }
             else{
-                WazeWrap.Eventsun.register('afterundoaction', this, checkSelection);
+                WazeWrap.Events.unregister('afterundoaction', this, checkSelection);
                 WazeWrap.Events.unregister('afteraction', this, checkSelection);
                 WazeWrap.Events.unregister('selectionchanged', this, checkSelection);
                 W.model.venues.off('objectschanged', ObjectsChanged);

--- a/WMEPIE.js
+++ b/WMEPIE.js
@@ -50,7 +50,7 @@ var UpdateObject, MultiAction;
     let hoursparser;
     let GLE;
     var catalog = [];
-    const updateMessage = "Disabling Google Link Enhancer when in Event mode";
+    const updateMessage = "Fixing typo in unregistering an event when disabling Show Closest Segment.";
 
     //Layer definitions
     {


### PR DESCRIPTION
Was fixed previously and broke with subsequent updates