### PR TITLE
perf: Merge PR #31 with enhancements - NavPointManager caching + UI/U…

### DIFF
--- a/WMEPIE.js
+++ b/WMEPIE.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         WME Place Interface Enhancements
 // @namespace    https://greasyfork.org/users/30701-justins83-waze
-// @version      2026.03.26.00
+// @version      2026.03.28.00
 // @description  Enhancements to various Place interfaces
 // @include      https://www.waze.com/editor*
 // @include      https://www.waze.com/*/editor*
@@ -48,8 +48,9 @@
     var wazePL;
     let hoursparser;
     let GLE;
+    let navPointManager = null;
     var catalog = [];
-    const updateMessage = 'Guard against WME Google Places layer — clicking a Google Place no longer causes errors';
+    const updateMessage = 'Performance optimization for NavPoint when moving venues. <br>Fixed PhotoViewer button responsiveness on smaller screens. <br>New places now open in Edit Mode. <br>Address editor auto-activates for all new places. <br>Fixed settings not being respected.';
     var lastSelectedFeature;
     const SCRIPT_VERSION = GM_info.script.version.toString();
     const SCRIPT_NAME = GM_info.script.name;
@@ -348,12 +349,23 @@
         }
     }
 
-    // SDK road type numeric constants — sdk.DataModel.Segments returns numeric roadType
-    // Always skip non-drivable types regardless of skipPLR/skipPrivate flags
-    // Find closest segment to a point using Turf.js and SDK segments.
-    // pointGeoJSON: WGS84 GeoJSON Point geometry {type:'Point', coordinates:[lon,lat]}
-    // Returns: { closestPoint: WGS84 GeoJSON Point geometry, segment: SDK Segment }
-    async function findClosestSegmentTurf(pointGeoJSON, skipPLR = false, skipPrivate = false) {
+    /**
+     * Find the closest road segment to a given point using Turf.js
+     *
+     * Searches all SDK segments and returns the one with minimum distance to the query point.
+     * Optionally skips parking lot roads (type 20) and/or private roads (type 17).
+     * All non-drivable road types are always skipped.
+     *
+     * Note: Made synchronous in PR #31 for better performance. Previously async but never
+     * actually performed async operations - removed unnecessary await overhead.
+     *
+     * @param {Object} pointGeoJSON - WGS84 GeoJSON Point geometry {type:'Point', coordinates:[lon,lat]}
+     * @param {boolean} [skipPLR=false] - If true, skip parking lot roads (roadType 20)
+     * @param {boolean} [skipPrivate=false] - If true, skip private roads (roadType 17) with blank names
+     * @param {Object} [sdkInstance=sdk] - SDK instance to use (defaults to global sdk, allows dependency injection for testing)
+     * @returns {Object|null} { closestPoint: WGS84 GeoJSON Point geometry, segment: SDK Segment } or null if no segments found
+     */
+    function findClosestSegmentTurf(pointGeoJSON, skipPLR = false, skipPrivate = false, sdkInstance = sdk) {
         try {
             if (!pointGeoJSON || !pointGeoJSON.coordinates) return null;
 
@@ -363,15 +375,15 @@
             let nearestPt = null;
             let closestSegment = null;
 
-            for (const seg of sdk.DataModel.Segments.getAll()) {
+            for (const seg of sdkInstance.DataModel.Segments.getAll()) {
                 if (!seg.geometry || seg.geometry.type !== 'LineString') continue;
                 const rt = seg.roadType;
                 if (_SKIP_ROAD_TYPES.has(rt)) continue; // always skip non-drivable
                 if (skipPLR && rt === 20 /* PARKING_LOT_ROAD */) continue;
                 if (skipPrivate && rt === 17 /* PRIVATE_ROAD */){
                     //debugger;
-                    const segment = sdk.DataModel.Segments.getById({ segmentId: seg.id });
-                    const street  = sdk.DataModel.Streets.getById({ streetId: segment.primaryStreetId });
+                    const segment = sdkInstance.DataModel.Segments.getById({ segmentId: seg.id });
+                    const street  = sdkInstance.DataModel.Streets.getById({ streetId: segment.primaryStreetId });
                     if(street?.name === null || street?.name == "")
                         continue;
                 }
@@ -535,6 +547,151 @@
     }
 
     function init2() {
+        /**
+         * NavPointManager - Caches venue navigation points to avoid expensive recalculation
+         *
+         * This manager significantly improves performance when moving venues by caching the
+         * "on-segment" navigation points and only invalidating when venue/segment data changes.
+         * Performance improvement: ~500% faster when moving venues in the Waze Editor.
+         *
+         * @class NavPointManager
+         * @param {Object} wmeSdk - The WME SDK instance for accessing data models and events
+         */
+        navPointManager = new (class NavPointManager {
+            /**
+             * Initialize NavPointManager with SDK reference and empty caches
+             * @param {Object} wmeSdk - The WME SDK instance
+             */
+            constructor(wmeSdk) {
+                this.sdk = wmeSdk;
+                /** @type {Map<string, Object>} Map of venue ID → cached navigation point */
+                this.navPoints = new Map();
+                /** @type {Set<Object>} Set of tracked event handlers for cleanup */
+                this.trackedEvents = new Set();
+            }
+
+            /**
+             * Generate a unique key for storing navigation points for a venue. Currently uses the venue ID, but can be extended to include other factors if needed.
+             * @param {Object} venue - SDK Venue object
+             * @returns {string} Unique key for the venue's navigation point
+             */
+            getNavPointKey(venue) {
+                return String(venue.id);
+            }
+
+            /**
+             * Register and track a data model event handler for later cleanup
+             * @private
+             * @param {string} eventName - WME SDK event name (e.g., 'wme-data-model-objects-changed')
+             * @param {Function} handler - Event handler callback function
+             */
+            _applyEventTracking(eventName, handler) {
+                const eventRecord = { eventName, eventHandler: handler };
+                this.sdk.Events.on(eventRecord);
+                this.trackedEvents.add(eventRecord);
+            }
+
+            /**
+             * Unregister all tracked event handlers and clear tracking set
+             * Called by stopTrackingChanges() to clean up event listeners
+             * @private
+             */
+            _revertAllTrackedEvents() {
+                for (const { eventName, eventHandler } of this.trackedEvents) {
+                    this.sdk.Events.off({ eventName, eventHandler });
+                }
+                this.trackedEvents.clear();
+            }
+
+            /**
+             * Start listening for venue and segment data model changes
+             * Registers handlers to invalidate cached navigation points when data changes
+             * Prevents duplicate handlers by calling stopTrackingChanges first
+             * @public
+             */
+            startTrackingChanges() {
+                this.stopTrackingChanges(); // ensure no duplicate handlers
+
+                const invalidationHandler = ({ dataModelName }) => {
+                    if (dataModelName !== 'venues' && dataModelName !== 'segments')
+                        return;
+
+                    this._invalidateAllNavPoints();
+                };
+
+                this._applyEventTracking('wme-data-model-object-state-deleted', invalidationHandler);
+                this._applyEventTracking('wme-data-model-objects-added', invalidationHandler);
+                this._applyEventTracking('wme-data-model-objects-changed', invalidationHandler);
+                this._applyEventTracking('wme-data-model-objects-removed', invalidationHandler);
+                this._applyEventTracking('wme-data-model-objects-saved', invalidationHandler);
+                // The following SDK calls won't be reverted by stopTrackingChanges, since they are shared SDK events that may be used by other features
+                this.sdk.Events.trackDataModelEvents({ dataModelName: 'venues' });
+                this.sdk.Events.trackDataModelEvents({ dataModelName: 'segments' });
+            }
+
+            /**
+             * Stop listening for data model changes and clear the navigation point cache
+             * Unregisters all event handlers added by startTrackingChanges()
+             * @public
+             */
+            stopTrackingChanges() {
+                this._revertAllTrackedEvents();
+                this._invalidateAllNavPoints();
+            }
+
+            /**
+             * Invalidate all cached navigation points, forcing recalculation on next access.
+             */
+            _invalidateAllNavPoints() {
+                this.navPoints.clear();
+            }
+
+            /**
+             * Get the raw navigation point for a venue, which is either the explicitly defined navigation point, the centroid of the polygon geometry, or the point geometry itself.
+             * @param {Object} venue
+             * @returns {Object|null} WGS84 GeoJSON Point geometry or null if it cannot be determined
+             */
+            getVenueRawNavPoint(venue) {
+                if (!venue || !venue.id || !venue.geometry) return null;
+                if (venue.navigationPoints && venue.navigationPoints.length > 0) return venue.navigationPoints[0].point;
+                if (venue.geometry.type === 'Polygon') return turf.centroid(venue.geometry).geometry;
+                return venue.geometry; // assume Point
+            }
+
+            /**
+             * Calculate the "on-segment" navigation point for a venue by finding the closest point on the nearest road segment to the venue's raw nav point.
+             * Caches the result in this.navPoints for future retrieval.
+             * @param {Object} venue - SDK Venue object
+             * @return {Object|null} WGS84 GeoJSON Point geometry of the on-segment nav point, or null if it cannot be calculated
+             */
+            calculateVenueOnSegmentNavPoint(venue) {
+                if (!venue || !venue.id || !venue.geometry) return null;
+
+                const navPoint = this.getVenueRawNavPoint(venue);
+                const closestSeg = findClosestSegmentTurf(navPoint, false, false, this.sdk);
+                if (!closestSeg || !closestSeg.closestPoint) return null;
+
+                this.navPoints.set(this.getNavPointKey(venue), closestSeg.closestPoint);
+                return closestSeg.closestPoint;
+            }
+
+            /**
+             * Get the navigation point for a venue, calculating and caching it if not already available.
+             * @param {Object} venue - SDK Venue object
+             * @returns {Object|null} WGS84 GeoJSON Point geometry or null if it cannot be determined
+             */
+            getVenueOnSegmentNavPoint(venue) {
+                if (!venue || !venue.id) return null;
+                const venueKey = this.getNavPointKey(venue);
+                if (!this.navPoints.has(venueKey)) {
+                    return this.calculateVenueOnSegmentNavPoint(venue);
+                }
+
+                return this.navPoints.get(venueKey);
+            }
+        })(sdk);
+        navPointManager.startTrackingChanges();
+
         // Collapsible section headers — state persisted in localStorage
         const PIE_LS_SECTIONS = 'WME_PIE_sectionStates';
         // Sections collapsed by default (id → true means collapsed)
@@ -670,12 +827,12 @@
 
         $('#_cbShowNavPointClosestSegmentOnHover').change(async function () {
             if (this.checked) {
-                navPointHandlers.mouseenter = async ({ featureId, layerName }) => {
+                navPointHandlers.mouseenter = ({ featureId, layerName }) => {
                     if (layerName !== 'venues') return;
                     const venue = sdk.DataModel.Venues.getById({ venueId: featureId });
                     if (!venue) return;
                     sdk.Map.removeAllFeaturesFromLayer({ layerName: _PIE_SHOW_STOP_POINTS_LAYER });
-                    await drawNavPointClosestSegmentLines(venue);
+                    drawNavPointClosestSegmentLines(venue);
                 };
                 navPointHandlers.mouseleave = ({ layerName }) => {
                     if (layerName !== 'venues') return;
@@ -791,10 +948,11 @@
         });
 
         $('#_cbEnablePhotoViewer').change(async function () {
-            if (this.checked) $('#launchDiv').css('display', 'block');
-            else {
+            if (this.checked) {
+                $('#launchDiv').addClass('pv-visible');
+            } else {
                 hide_visio();
-                $('#launchDiv').css('display', 'none');
+                $('#launchDiv').removeClass('pv-visible');
             }
         });
 
@@ -862,12 +1020,12 @@
         $('#pieSimplifyFactor')[0].value = settings.SimplifyFactor;
 
         if (settings.ShowNavPointClosestSegmentOnHover) {
-            navPointHandlers.mouseenter = async ({ featureId, layerName }) => {
+            navPointHandlers.mouseenter = ({ featureId, layerName }) => {
                 if (layerName !== 'venues') return;
                 const venue = sdk.DataModel.Venues.getById({ venueId: featureId });
                 if (!venue) return;
                 sdk.Map.removeAllFeaturesFromLayer({ layerName: _PIE_SHOW_STOP_POINTS_LAYER });
-                await drawNavPointClosestSegmentLines(venue);
+                drawNavPointClosestSegmentLines(venue);
             };
             navPointHandlers.mouseleave = ({ layerName }) => {
                 if (layerName !== 'venues') return;
@@ -1321,11 +1479,16 @@
         //Icon near chat
         let launchDiv = document.createElement('div');
         launchDiv.id = 'launchDiv';
-        launchDiv.style.cssText = 'position:absolute; z-index:10000; bottom:20px; left:190px; display:' + (settings.EnablePhotoViewer ? 'block' : 'none') + ';';
+        launchDiv.setAttribute('data-pie-tip', 'Photo Viewer\nPlace Interface Enhancements');
+
+        // Use CSS class for visibility instead of inline display style (responsive design)
+        if (settings.EnablePhotoViewer) {
+            launchDiv.classList.add('pv-visible');
+        }
+
         const launchButton = document.createElement('button');
         launchButton.id = 'photoViewerButton';
         launchButton.type = 'button';
-        launchDiv.setAttribute('data-pie-tip', 'Photo Viewer\nPlace Interface Enhancements');
         launchButton.innerHTML = '<i class="fa fa-picture-o"></i>';
         launchButton.onmouseenter = togglePhotoViewerMouseEvent;
         launchDiv.appendChild(launchButton);
@@ -1373,6 +1536,30 @@
                 launchDiv.style.bottom = 'auto';
             }
         } catch (e) {}
+
+        /**
+         * Keep PhotoViewer button within map bounds when window resizes
+         * Prevents button from disappearing off-screen on smaller viewports
+         */
+        window.addEventListener('resize', function () {
+            const mapEl = document.querySelector(WME_DOM.map);
+            if (!mapEl || !launchDiv) return;
+
+            // Only constrain if button has explicit positioning (was dragged)
+            if (launchDiv.style.top === '' || launchDiv.style.left === '') return;
+
+            const mr = mapEl.getBoundingClientRect();
+            const currentLeft = parseFloat(launchDiv.style.left) || 0;
+            const currentTop = parseFloat(launchDiv.style.top) || 0;
+
+            // Clamp position to map bounds with padding
+            const padding = 10;
+            const newLeft = Math.max(padding, Math.min(currentLeft, mr.width - launchDiv.offsetWidth - padding));
+            const newTop = Math.max(padding, Math.min(currentTop, mr.height - launchDiv.offsetHeight - padding));
+
+            launchDiv.style.left = newLeft + 'px';
+            launchDiv.style.top = newTop + 'px';
+        });
 
         $('#sortBy')[0].value = settings.sortBy;
         $('#sortOrder')[0].value = settings.sortOrder;
@@ -1994,24 +2181,36 @@
         DisplayPlaceNames();
     }
 
-    async function drawNavPointClosestSegmentLines(sdkVenue) {
+    /**
+     * Draw visual indicators connecting a venue's navigation point to the nearest road segment
+     *
+     * Uses NavPointManager for cached calculations (PR #31 optimization). Draws two sets of lines:
+     * 1. From venue center to "raw" navigation point (if explicit nav point or polygon centroid)
+     * 2. From raw nav point to on-segment nav point (closest point on nearest road)
+     *
+     * Only draws when map zoom level >= 16 to avoid clutter at lower zoom levels.
+     * Returns silently if no nearby segments found (guard against null coordinates).
+     *
+     * Note: Made synchronous in PR #31 (removed unnecessary async/await).
+     *
+     * @param {Object} sdkVenue - SDK Venue object with geometry and navigationPoints properties
+     */
+    function drawNavPointClosestSegmentLines(sdkVenue) {
         try {
             if (sdk.Map.getZoomLevel() < 16) return;
             const isArea = sdkVenue.geometry.type === 'Polygon';
 
-            // navPoint is a WGS84 GeoJSON Point geometry
-            let navPoint;
-            if (sdkVenue.navigationPoints && sdkVenue.navigationPoints.length > 0) navPoint = sdkVenue.navigationPoints[0].point;
-            else navPoint = isArea ? turf.centroid(sdkVenue.geometry).geometry : sdkVenue.geometry;
+            const navPoint = navPointManager.getVenueRawNavPoint(sdkVenue);
+            const targetNavPoint = navPointManager.getVenueOnSegmentNavPoint(sdkVenue);
 
-            //nav point to closest segment
-            const closestSeg = await findClosestSegmentTurf(navPoint, false, false);
-            if (!closestSeg) return;
+            // Guard against null returns
+            if (!navPoint || !targetNavPoint) return;
+
             sdk.Map.addFeaturesToLayer({
                 layerName: _PIE_SHOW_STOP_POINTS_LAYER,
                 features: [
-                    turf.lineString([navPoint.coordinates, closestSeg.closestPoint.coordinates], { styleName: 'lineStyleToClosestSeg' }, { id: 'pie_hover_line_to_seg' }),
-                    turf.point(closestSeg.closestPoint.coordinates, { styleName: 'pointStyle' }, { id: 'pie_hover_pt_seg' }),
+                    turf.lineString([navPoint.coordinates, targetNavPoint.coordinates], { styleName: 'lineStyleToClosestSeg' }, { id: 'pie_hover_line_to_seg' }),
+                    turf.point(targetNavPoint.coordinates, { styleName: 'pointStyle' }, { id: 'pie_hover_pt_seg' }),
                 ],
             });
 
@@ -2063,9 +2262,21 @@
         });
     }
 
-    // navPointGeoJSON: WGS84 GeoJSON Point geometry
-    async function drawNearestLanding(navPointGeoJSON, ignorePLR = false, ignorePrivate = false) {
-        const closestSegment = await findClosestSegmentTurf(navPointGeoJSON, ignorePLR, ignorePrivate);
+    /**
+     * Draw a line from a navigation point to the nearest road segment
+     *
+     * Finds the closest segment to the provided point and draws a line + point marker
+     * connecting them on the map's PIE_CLOSEST_SEGMENT_LAYER. Clears any previous features
+     * before drawing the new line.
+     *
+     * Note: Made synchronous in PR #31 (removed unnecessary async/await).
+     *
+     * @param {Object} navPointGeoJSON - WGS84 GeoJSON Point geometry {type:'Point', coordinates:[lon,lat]}
+     * @param {boolean} [ignorePLR=false] - If true, skip parking lot roads (roadType 20)
+     * @param {boolean} [ignorePrivate=false] - If true, skip private roads (roadType 17)
+     */
+    function drawNearestLanding(navPointGeoJSON, ignorePLR = false, ignorePrivate = false) {
+        const closestSegment = findClosestSegmentTurf(navPointGeoJSON, ignorePLR, ignorePrivate);
         if (!closestSegment) return;
         clearClosesetSegmentLayerFeatures();
         drawLine(navPointGeoJSON, closestSegment.closestPoint, 'lineStyleToClosestSeg', 'pointStyle');
@@ -2303,13 +2514,15 @@
         sdk.DataModel.Venues.updateVenue({ venueId: newPlaceId, lockRank: Number(settings.DefaultLockLevel) });
 
         const searchPoint = turf.centroid(geometry).geometry;
-        const closestSeg = await findClosestSegmentTurf(searchPoint, settings.SkipPLR, settings.SkipPLR);
+        const closestSeg = findClosestSegmentTurf(searchPoint, settings.SkipPLR, false);
 
         if (closestSeg) {
             const sdkSeg = closestSeg.segment;
             if (settings.UseCityFromClosestSeg || settings.UseStreetFromClosestSeg) {
                 let streetId = sdkSeg.primaryStreetId;
-                if (settings.UseAltCity) {
+
+                // Only apply alt city logic if UseCityFromClosestSeg is ON
+                if (settings.UseCityFromClosestSeg && settings.UseAltCity) {
                     const primaryCity = sdk.DataModel.Cities.getById({ cityId: sdk.DataModel.Streets.getById({ streetId }).cityId });
                     if (primaryCity.name === '' && sdkSeg.alternateStreetIds.length > 0) {
                         for (const altId of sdkSeg.alternateStreetIds) {
@@ -2321,17 +2534,28 @@
                         }
                     }
                 }
-                sdk.DataModel.Venues.updateAddress({
-                    venueId: newPlaceId,
-                    streetId: settings.UseStreetFromClosestSeg ? streetId : null,
-                    houseNumber: '',
-                });
-            }
-            await new Promise((r) => setTimeout(r, 20));
-            sdk.Editing.setSelection({ selection: { objectType: 'venue', ids: [newPlaceId] } });
-        } else console.log('WMEPIE - No segment found; cannot set street or city name.');
 
-        if (category === resCategory && settings.EditRPPAfterCreated) setTimeout(editRPPAddress, 50);
+                // Only update street if UseStreetFromClosestSeg is ON
+                if (settings.UseStreetFromClosestSeg) {
+                    sdk.DataModel.Venues.updateAddress({
+                        venueId: newPlaceId,
+                        streetId: streetId,
+                        houseNumber: '',
+                    });
+                }
+            }
+        } else {
+            console.log('WMEPIE - No segment found; cannot set street or city name.');
+        }
+
+        // Always open newly created places in Edit Mode (not View Mode)
+        await new Promise((r) => setTimeout(r, 20));
+        sdk.Editing.setSelection({ selection: { objectType: 'venue', ids: [newPlaceId] } });
+
+        // Only activate address editor if EditRPPAfterCreated setting is ON
+        if (settings.EditRPPAfterCreated) {
+            setTimeout(editRPPAddress, 50);
+        }
     }
 
     async function delayFire(ms, func) {
@@ -3446,14 +3670,89 @@
       [wz-theme="dark"] .pie-geom-apply-btn:hover { background: #0052a3; }
 
       /* Photo Viewer launch button — matches WME overlay-button visual style */
-      #launchDiv { cursor: grab; position: relative; }
-      #launchDiv[data-pie-tip]::after { content: attr(data-pie-tip); position: absolute; bottom: calc(100% + 8px); left: 50%; transform: translateX(-50%); background: #1a1a1a; color: #fff; font-family: Arial, sans-serif; font-size: 11px; line-height: 1.6; white-space: pre; text-align: center; padding: 5px 10px; border-radius: 6px; box-shadow: 0 2px 8px rgba(0,0,0,0.35); pointer-events: none; opacity: 0; transition: opacity 0.15s; z-index: 10001; }
+      /* Positioned absolutely on map with responsive layout for different screen sizes */
+      #launchDiv {
+        position: absolute;
+        cursor: grab;
+        z-index: 10000;
+        bottom: 20px;
+        left: 190px;
+        display: none;
+      }
+
+      /* Large screens (desktop) — default position near chat/sidebar */
+      @media (min-width: 1400px) {
+        #launchDiv { left: 190px; bottom: 20px; }
+      }
+
+      /* Medium screens — shift button closer to center */
+      @media (min-width: 1024px) and (max-width: 1399px) {
+        #launchDiv { left: 120px; bottom: 20px; }
+      }
+
+      /* Small screens (tablets/narrow) — move to bottom-left to avoid UI clutter */
+      @media (max-width: 1023px) {
+        #launchDiv { left: 60px; bottom: 20px; }
+      }
+
+      /* Extra small screens — ensure it stays visible */
+      @media (max-width: 768px) {
+        #launchDiv { left: 20px; bottom: 20px; }
+      }
+
+      /* Show/hide visibility control */
+      #launchDiv.pv-visible { display: block; }
+
+      /* Tooltip styling */
+      #launchDiv[data-pie-tip]::after {
+        content: attr(data-pie-tip);
+        position: absolute;
+        bottom: calc(100% + 8px);
+        left: 50%;
+        transform: translateX(-50%);
+        background: #1a1a1a;
+        color: #fff;
+        font-family: Arial, sans-serif;
+        font-size: 11px;
+        line-height: 1.6;
+        white-space: pre;
+        text-align: center;
+        padding: 5px 10px;
+        border-radius: 6px;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.35);
+        pointer-events: none;
+        opacity: 0;
+        transition: opacity 0.15s;
+        z-index: 10001;
+      }
       #launchDiv[data-pie-tip]:hover::after { opacity: 1; }
       #launchDiv.pie-tip-off::after { display: none; }
-      #photoViewerButton { display: flex; align-items: center; justify-content: center; width: 40px; height: 40px; border: none; border-radius: 8px; background: var(--surface_default, #fff); color: var(--content_default, #1a1a1a); box-shadow: 0 1px 4px rgba(0,0,0,0.18); cursor: inherit; padding: 0; transition: background 0.12s, box-shadow 0.12s; }
+
+      /* Button styling */
+      #photoViewerButton {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 40px;
+        height: 40px;
+        border: none;
+        border-radius: 8px;
+        background: var(--surface_default, #fff);
+        color: var(--content_default, #1a1a1a);
+        box-shadow: 0 1px 4px rgba(0,0,0,0.18);
+        cursor: inherit;
+        padding: 0;
+        transition: background 0.12s, box-shadow 0.12s;
+      }
       #photoViewerButton .fa { font-size: 18px; }
-      #photoViewerButton:hover { background: var(--surface_hover, #f0f0f0); box-shadow: 0 2px 8px rgba(0,0,0,0.22); }
-      #photoViewerButton:active { background: var(--surface_active, #e4e4e4); box-shadow: 0 1px 2px rgba(0,0,0,0.14); }
+      #photoViewerButton:hover {
+        background: var(--surface_hover, #f0f0f0);
+        box-shadow: 0 2px 8px rgba(0,0,0,0.22);
+      }
+      #photoViewerButton:active {
+        background: var(--surface_active, #e4e4e4);
+        box-shadow: 0 1px 2px rgba(0,0,0,0.14);
+      }
     `;
       $('<style type="text/css">' + css + '</style>').appendTo('head');
   }
@@ -3676,8 +3975,8 @@
                     ShowGPIDTooltip: 'External provider tooltip',
                     ShowGPIDTooltipTitle: 'Displays a tooltip with the external provider information',
                     NewPlaces: 'New Places',
-                    EditRPPAfterCreate: 'Open RPP address on create',
-                    EditRPPAfterCreateTitle: 'Automatically opens the RPP address edit window and focuses on the House Number entry',
+                    EditRPPAfterCreate: 'Open address on create',
+                    EditRPPAfterCreateTitle: 'Automatically opens the address editor for any new place and focuses on the House Number entry',
                     UseStreetFromClosestSegment: 'Street from closest segment',
                     UseStreetFromClosestSegmentTitle: "Pulls the street name from the closest visible segment and inserts into the new Place's address",
                     UseCityFromClosestSegment: 'City from closest segment',
@@ -3812,8 +4111,8 @@
                     ShowGPIDTooltip: 'Información del proveedor externo',
                     ShowGPIDTooltipTitle: 'Muestra un texto con la información del proveedor externo',
                     NewPlaces: 'Nuevos lugares',
-                    EditRPPAfterCreate: 'Editar la dirección del RPP una vez creada',
-                    EditRPPAfterCreateTitle: 'Automáticamente abre la ventana de edición en la dirección del lugar residencial y se enfoca en el campo de número de casa',
+                    EditRPPAfterCreate: 'Abrir dirección al crear',
+                    EditRPPAfterCreateTitle: 'Abre automáticamente el editor de dirección para cualquier nuevo lugar y se enfoca en el campo de número de casa',
                     UseStreetFromClosestSegment: 'Calle del segmento más cercano',
                     UseStreetFromClosestSegmentTitle: 'Extrae el nombre de la calle del segmento visible más cercano y lo agrega en la dirección del nuevo lugar',
                     UseCityFromClosestSegment: 'Ciudad del segmento más cercano',
@@ -3945,8 +4244,8 @@
                     ShowGPIDTooltip: 'Infobulle fournisseur externe',
                     ShowGPIDTooltipTitle: 'Affiche une infobulle avec les informations du fournisseur externe',
                     NewPlaces: 'Nouveaux Lieux',
-                    EditRPPAfterCreate: "Editer l'adresse du résidentiel après création",
-                    EditRPPAfterCreateTitle: "Ouvre automatiquement la zone d'édition de l'adresse du lieu résidentiel et se positionne sur la saisie du n° de rue",
+                    EditRPPAfterCreate: "Ouvrir l'adresse à la création",
+                    EditRPPAfterCreateTitle: "Ouvre automatiquement l'éditeur d'adresse pour tout nouveau lieu et se positionne sur le champ de numéro de maison",
                     UseStreetFromClosestSegment: 'Rue du segment le plus proche',
                     UseStreetFromClosestSegmentTitle: "Prend le nom de rue du segment visible le plus proche et l'insère dans l'adresse du nouveau lieu",
                     UseCityFromClosestSegment: 'Ville du segment le plus proche',


### PR DESCRIPTION
…X improvements

Credits: Based on PR #31 by davidsl4 (WazeDev/WME-Place-Interface-Enhancements#31)

This commit merges the performance optimization from PR #31 with critical bug fixes and UI/UX improvements:

Core Feature (from PR #31):
- Add NavPointManager class to cache venue navigation points
- Eliminates expensive recalculations during venue movement (~500% performance improvement)
- Removes unnecessary async/await keywords from synchronous functions
- Refactor findClosestSegmentTurf to accept optional sdkInstance parameter for testability
- Comprehensive JSDoc documentation for all modified functions and classes

Bug Fixes Applied:
1. Add null checks in drawNavPointClosestSegmentLines for navPoint and targetNavPoint
   - Prevents TypeError crash when no nearby road segments are found
   - Restores guard pattern from original code

2. Fix argument copy-paste error in createPlace function
   - Changed findClosestSegmentTurf(searchPoint, settings.SkipPLR, settings.SkipPLR)
   - To: findClosestSegmentTurf(searchPoint, settings.SkipPLR, false)
   - Correctly passes false for skipPrivate (no SkipPrivate setting exists)

3. Move NavPointManager initialization to init2() instead of module scope
   - Ensures SDK is fully initialized before event tracking begins
   - Aligns with established bootstrap pattern in codebase

4. Fix variable naming in NavPointManager event tracking
   - Changed eventHandler variable name to eventRecord to prevent shadowing confusion
   - Maintains proper handler reference management in event tracking

5. Fix settings not being respected in place creation logic
   - UseAltCity now only applies when UseCityFromClosestSeg is ON
   - Street is only set when UseStreetFromClosestSeg is ON
   - Each setting now properly controls its corresponding behavior

UI/UX Improvements:
1. PhotoViewer button responsive positioning (CSS media queries)
   - Repositions button based on screen size (1400px+, 1024px, 768px, mobile)
   - Stays visible on smaller viewports with dynamic bounds checking
   - Window resize handler prevents button from going off-screen

2. All new places now open in Edit Mode (not View Mode)
   - Moved sdk.Editing.setSelection outside segment check
   - Now applies to ALL place types, regardless of closest segment
   - Consistent user experience for place creation

3. Address editor auto-activates for all new places
   - Previously only for Residential with EditRPPAfterCreated setting
   - Now applies universally when setting is enabled
   - Renamed setting from "Open RPP address on create" to "Open address on create" for clarity

4. Fixed settings logic for place creation
   - Each setting now properly guards its feature
   - EditRPPAfterCreated setting is now respected (address editor only activates when ON)
   - UseStreetFromClosestSeg/UseCityFromClosestSeg work independently